### PR TITLE
Add sale logging and annual fee projections to DashNex ROI dashboard

### DIFF
--- a/dashnex-roi.html
+++ b/dashnex-roi.html
@@ -1,0 +1,402 @@
+<!doctype html>
+<html lang="en" class="h-full antialiased">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DashNex Affiliate ROI Dashboard – assets.gabrieldalton.com</title>
+  <meta name="description" content="Interactive calculator to track DashNex affiliate payments, payouts, and ROI projections." />
+  <meta name="color-scheme" content="light dark" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="h-full bg-slate-50 text-slate-900 dark:bg-slate-950 dark:text-slate-100">
+
+  <main class="min-h-full bg-gradient-to-b from-slate-100 via-white to-slate-100 dark:from-slate-950 dark:via-slate-900 dark:to-slate-950 p-6">
+    <section class="mx-auto flex w-full max-w-5xl flex-col gap-6">
+      <nav class="flex justify-end">
+        <a
+          href="/"
+          class="inline-flex items-center gap-2 rounded-lg border border-slate-200 bg-white/80 px-3 py-2 text-xs font-medium text-slate-600 shadow-sm transition hover:border-slate-300 hover:bg-white dark:border-slate-800 dark:bg-slate-900/80 dark:text-slate-300 dark:hover:border-slate-700"
+        >
+          <span aria-hidden="true">←</span>
+          Back to CDN home
+        </a>
+      </nav>
+      <header class="rounded-2xl border border-slate-200 bg-white/90 p-8 shadow-xl backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+        <h1 class="text-3xl font-bold tracking-tight text-center">DashNex Affiliate ROI Tracker</h1>
+        <p class="mt-3 text-center text-sm text-slate-600 dark:text-slate-300">
+          Interactive dashboard to monitor your DashNex affiliate payments, revenue, and projected return on investment.
+        </p>
+      </header>
+
+      <section class="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-800 dark:bg-slate-900" aria-labelledby="roi-overview-title">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h2 id="roi-overview-title" class="text-lg font-semibold text-slate-900 dark:text-slate-100">ROI overview</h2>
+              <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">A summary of your affiliate investment to date.</p>
+            </div>
+            <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300" id="payback-status">On track</span>
+          </div>
+
+          <dl class="mt-6 grid grid-cols-1 gap-4 text-sm sm:grid-cols-2" id="summary-grid">
+            <div class="rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60">
+              <dt class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Total invested</dt>
+              <dd class="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-100" id="total-invested">$0.00</dd>
+            </div>
+            <div class="rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60">
+              <dt class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Revenue received</dt>
+              <dd class="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-100" id="total-received">$0.00</dd>
+            </div>
+            <div class="rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60">
+              <dt class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">Net profit</dt>
+              <dd class="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-100" id="net-profit">$0.00</dd>
+            </div>
+            <div class="rounded-xl bg-slate-50 p-4 dark:bg-slate-800/60">
+              <dt class="text-xs uppercase tracking-wide text-slate-500 dark:text-slate-400">ROI</dt>
+              <dd class="mt-1 text-2xl font-semibold text-slate-900 dark:text-slate-100"><span id="roi-percentage">0</span>%</dd>
+            </div>
+          </dl>
+
+          <div class="mt-6 grid gap-4 text-xs text-slate-600 dark:text-slate-300 sm:grid-cols-3">
+            <p><span class="font-semibold text-slate-900 dark:text-slate-100" id="payment-count">0</span> payments made</p>
+            <p><span class="font-semibold text-slate-900 dark:text-slate-100" id="payout-count">0</span> payouts received</p>
+            <p>Payback status: <span class="font-semibold text-slate-900 dark:text-slate-100" id="payback-label">Pending</span></p>
+          </div>
+        </article>
+
+        <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-800 dark:bg-slate-900" aria-labelledby="roi-estimator-title">
+          <h2 id="roi-estimator-title" class="text-lg font-semibold text-slate-900 dark:text-slate-100">ROI estimator</h2>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+            Quickly model how future payouts change your ROI. Adjust the projected revenue slider, include future annual fees, or enter an exact value below.
+          </p>
+
+          <label for="projected-revenue" class="mt-6 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Projected additional revenue ($)</label>
+          <input type="range" id="projected-revenue" min="0" max="2000" value="0" step="10" class="mt-2 w-full accent-emerald-500" />
+          <div class="mt-3 flex items-center gap-2">
+            <input type="number" id="projected-revenue-input" min="0" step="10" value="0" class="w-32 rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100" />
+            <button type="button" id="reset-estimator" class="rounded-lg border border-transparent bg-slate-100 px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-200 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700">Reset</button>
+          </div>
+
+          <label for="future-fee-years" class="mt-6 block text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Future service years to include</label>
+          <div class="mt-2 flex items-center gap-3">
+            <input type="number" id="future-fee-years" min="0" max="10" value="1" class="w-24 rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100" />
+            <p class="text-xs text-slate-500 dark:text-slate-400">Each future year adds <span class="font-medium text-slate-700 dark:text-slate-200">$147</span> to your investment.</p>
+          </div>
+
+          <dl class="mt-6 space-y-3 rounded-xl bg-slate-50 p-4 text-sm text-slate-700 shadow-inner dark:bg-slate-800/60 dark:text-slate-200">
+            <div class="flex items-center justify-between">
+              <dt>Projected total revenue</dt>
+              <dd class="font-semibold" id="projected-total-revenue">$0.00</dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt>Future DashNex fees</dt>
+              <dd class="font-semibold" id="projected-future-fees">$0.00</dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt>Projected total invested</dt>
+              <dd class="font-semibold" id="projected-total-invested">$0.00</dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt>Projected net profit</dt>
+              <dd class="font-semibold" id="projected-net-profit">$0.00</dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt>Projected ROI</dt>
+              <dd class="font-semibold"><span id="projected-roi">0</span>%</dd>
+            </div>
+          </dl>
+        </article>
+
+        <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-800 dark:bg-slate-900" aria-labelledby="add-sale-title">
+          <h2 id="add-sale-title" class="text-lg font-semibold text-slate-900 dark:text-slate-100">Record a new sale</h2>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">Keep your ROI up to date by logging new affiliate payouts as soon as you receive them.</p>
+
+          <form id="add-sale-form" class="mt-4 space-y-4">
+            <div>
+              <label for="sale-date" class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Date &amp; time</label>
+              <input type="datetime-local" id="sale-date" name="sale-date" class="mt-1 w-full rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100" required />
+            </div>
+            <div>
+              <label for="sale-type" class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Payment type</label>
+              <input type="text" id="sale-type" name="sale-type" placeholder="PayPal" class="mt-1 w-full rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100" />
+            </div>
+            <div>
+              <label for="sale-amount" class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Amount received (USD)</label>
+              <input type="number" id="sale-amount" name="sale-amount" min="0" step="0.01" class="mt-1 w-full rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100" required />
+            </div>
+            <div>
+              <label for="sale-status" class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">Status</label>
+              <select id="sale-status" name="sale-status" class="mt-1 w-full rounded-lg border border-slate-200 bg-white p-2 text-sm text-slate-900 shadow-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100">
+                <option value="Paid" selected>Paid</option>
+                <option value="Pending">Pending</option>
+              </select>
+            </div>
+            <button type="submit" class="w-full rounded-lg bg-emerald-500 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2 focus:ring-offset-white dark:focus:ring-offset-slate-900">Add sale</button>
+            <p id="sale-feedback" class="text-xs text-emerald-600 dark:text-emerald-300" role="status" aria-live="polite"></p>
+          </form>
+        </article>
+      </section>
+
+      <section class="grid gap-6 lg:grid-cols-2">
+        <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-800 dark:bg-slate-900" aria-labelledby="payments-title">
+          <h2 id="payments-title" class="text-lg font-semibold text-slate-900 dark:text-slate-100">Payments to DashNex</h2>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Track every invoice you've paid to DashNex for affiliate services.</p>
+
+          <div class="mt-4 overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800">
+            <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-300">
+                <tr>
+                  <th scope="col" class="px-4 py-3 text-left">Date</th>
+                  <th scope="col" class="px-4 py-3 text-left">Invoice</th>
+                  <th scope="col" class="px-4 py-3 text-left">Method</th>
+                  <th scope="col" class="px-4 py-3 text-right">Amount</th>
+                  <th scope="col" class="px-4 py-3 text-right">Status</th>
+                </tr>
+              </thead>
+              <tbody id="payments-body" class="divide-y divide-slate-200 dark:divide-slate-800"></tbody>
+            </table>
+          </div>
+        </article>
+
+        <article class="rounded-2xl border border-slate-200 bg-white p-6 shadow-lg dark:border-slate-800 dark:bg-slate-900" aria-labelledby="payouts-title">
+          <h2 id="payouts-title" class="text-lg font-semibold text-slate-900 dark:text-slate-100">Affiliate payouts received</h2>
+          <p class="mt-1 text-sm text-slate-600 dark:text-slate-300">Payments you've received from DashNex for affiliate activity.</p>
+
+          <div class="mt-4 overflow-hidden rounded-xl border border-slate-200 dark:border-slate-800">
+            <table class="min-w-full divide-y divide-slate-200 text-sm dark:divide-slate-800">
+              <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-500 dark:bg-slate-800 dark:text-slate-300">
+                <tr>
+                  <th scope="col" class="px-4 py-3 text-left">Date</th>
+                  <th scope="col" class="px-4 py-3 text-left">Type</th>
+                  <th scope="col" class="px-4 py-3 text-right">Amount</th>
+                  <th scope="col" class="px-4 py-3 text-right">Status</th>
+                </tr>
+              </thead>
+              <tbody id="payouts-body" class="divide-y divide-slate-200 dark:divide-slate-800"></tbody>
+            </table>
+          </div>
+        </article>
+      </section>
+
+      <footer class="mt-4 text-center text-xs text-slate-500 dark:text-slate-400">
+        © <span class="tabular-nums" id="year"></span> gabrieldalton.com
+      </footer>
+    </section>
+  </main>
+
+  <script>
+    const ANNUAL_FEE = 147;
+
+    const payments = [
+      { date: 'Aug 26, 2025', invoice: 'DNX56985', method: 'DashNex', amount: 147, status: 'Paid', timestamp: Date.parse('2025-08-26T00:00:00') },
+      { date: 'Aug 26, 2024', invoice: 'DNX50115', method: 'DashNex', amount: 147, status: 'Paid', timestamp: Date.parse('2024-08-26T00:00:00') },
+    ];
+
+    const payouts = [
+      { date: 'Dec 26, 2024 19:56', type: 'PayPal', amount: 156.5, status: 'Paid', timestamp: Date.parse('2024-12-26T19:56:00') },
+      { date: 'Oct 20, 2024 20:32', type: 'PayPal', amount: 164.5, status: 'Paid', timestamp: Date.parse('2024-10-20T20:32:00') },
+    ];
+
+    const numberFormatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+    });
+
+    const dateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+
+    let projectedRevenueValue = 0;
+    let futureFeeYearsValue = 1;
+
+    function calculateTotals() {
+      const totalInvested = payments.reduce((sum, payment) => sum + payment.amount, 0);
+      const totalReceived = payouts.reduce((sum, payout) => sum + payout.amount, 0);
+      const netProfit = totalReceived - totalInvested;
+      const roi = totalInvested === 0 ? 0 : ((netProfit / totalInvested) * 100);
+
+      return { totalInvested, totalReceived, netProfit, roi };
+    }
+
+    function updateSummary() {
+      const { totalInvested, totalReceived, netProfit, roi } = calculateTotals();
+
+      document.getElementById('total-invested').textContent = numberFormatter.format(totalInvested);
+      document.getElementById('total-received').textContent = numberFormatter.format(totalReceived);
+      document.getElementById('net-profit').textContent = numberFormatter.format(netProfit);
+      document.getElementById('roi-percentage').textContent = roi.toFixed(1);
+
+      document.getElementById('payment-count').textContent = payments.length;
+      document.getElementById('payout-count').textContent = payouts.length;
+
+      const paybackLabel = document.getElementById('payback-label');
+      const paybackStatus = document.getElementById('payback-status');
+      paybackStatus.classList.remove('bg-emerald-100', 'text-emerald-700', 'bg-emerald-500/10', 'text-emerald-400', 'bg-amber-100', 'text-amber-700');
+
+      if (netProfit >= 0) {
+        paybackLabel.textContent = 'Break-even reached';
+        paybackStatus.textContent = 'Profitable';
+        paybackStatus.classList.add('bg-emerald-500/10', 'text-emerald-400');
+      } else {
+        paybackLabel.textContent = 'Still recovering';
+        paybackStatus.textContent = 'In progress';
+        paybackStatus.classList.add('bg-amber-100', 'text-amber-700');
+      }
+    }
+
+    function renderTable(data, tableBodyId, columns, sortFn) {
+      const tbody = document.getElementById(tableBodyId);
+      tbody.innerHTML = '';
+      const rows = sortFn ? [...data].sort(sortFn) : [...data];
+
+      rows.forEach((row) => {
+        const tr = document.createElement('tr');
+        tr.className = 'bg-white hover:bg-slate-50 transition-colors dark:bg-slate-900 dark:hover:bg-slate-800';
+
+        columns.forEach((column) => {
+          const td = document.createElement('td');
+          td.className = column.align === 'right' ? 'px-4 py-3 text-right text-slate-600 dark:text-slate-200' : 'px-4 py-3 text-slate-600 dark:text-slate-200';
+          const value = row[column.key];
+          td.textContent = column.format ? column.format(value, row) : value;
+          tr.appendChild(td);
+        });
+
+        tbody.appendChild(tr);
+      });
+    }
+
+    function renderPayments() {
+      renderTable(payments, 'payments-body', [
+        { key: 'date' },
+        { key: 'invoice' },
+        { key: 'method' },
+        { key: 'amount', align: 'right', format: (value) => numberFormatter.format(value) },
+        { key: 'status', align: 'right' },
+      ], (a, b) => b.timestamp - a.timestamp);
+    }
+
+    function renderPayouts() {
+      renderTable(payouts, 'payouts-body', [
+        { key: 'date' },
+        { key: 'type' },
+        { key: 'amount', align: 'right', format: (value) => numberFormatter.format(value) },
+        { key: 'status', align: 'right' },
+      ], (a, b) => b.timestamp - a.timestamp);
+    }
+
+    function updateProjection(projectedRevenue = projectedRevenueValue, futureYears = futureFeeYearsValue) {
+      projectedRevenueValue = projectedRevenue;
+      futureFeeYearsValue = futureYears;
+
+      const { totalInvested, totalReceived } = calculateTotals();
+
+      const projectedTotalRevenue = totalReceived + projectedRevenueValue;
+      const projectedFutureFees = futureFeeYearsValue * ANNUAL_FEE;
+      const projectedTotalInvested = totalInvested + projectedFutureFees;
+      const projectedNetProfit = projectedTotalRevenue - projectedTotalInvested;
+      const projectedROI = projectedTotalInvested === 0 ? 0 : ((projectedNetProfit / projectedTotalInvested) * 100);
+
+      document.getElementById('projected-total-revenue').textContent = numberFormatter.format(projectedTotalRevenue);
+      document.getElementById('projected-future-fees').textContent = numberFormatter.format(projectedFutureFees);
+      document.getElementById('projected-total-invested').textContent = numberFormatter.format(projectedTotalInvested);
+      document.getElementById('projected-net-profit').textContent = numberFormatter.format(projectedNetProfit);
+      document.getElementById('projected-roi').textContent = projectedROI.toFixed(1);
+    }
+
+    function renderDashboard() {
+      renderPayments();
+      renderPayouts();
+      updateSummary();
+      updateProjection();
+    }
+
+    const projectedRevenueSlider = document.getElementById('projected-revenue');
+    const projectedRevenueInput = document.getElementById('projected-revenue-input');
+    const futureFeeYearsInput = document.getElementById('future-fee-years');
+    const resetButton = document.getElementById('reset-estimator');
+
+    projectedRevenueSlider.addEventListener('input', (event) => {
+      const value = Number(event.target.value);
+      projectedRevenueInput.value = value;
+      updateProjection(value, futureFeeYearsValue);
+    });
+
+    projectedRevenueInput.addEventListener('input', (event) => {
+      const value = Number(event.target.value || 0);
+      projectedRevenueSlider.value = value;
+      updateProjection(value, futureFeeYearsValue);
+    });
+
+    futureFeeYearsInput.addEventListener('input', (event) => {
+      const value = Math.max(0, Math.min(10, Number(event.target.value || 0)));
+      event.target.value = value;
+      updateProjection(projectedRevenueValue, value);
+    });
+
+    resetButton.addEventListener('click', () => {
+      projectedRevenueSlider.value = 0;
+      projectedRevenueInput.value = 0;
+      futureFeeYearsInput.value = 1;
+      updateProjection(0, 1);
+    });
+
+    const addSaleForm = document.getElementById('add-sale-form');
+    const saleDateInput = document.getElementById('sale-date');
+    const saleTypeInput = document.getElementById('sale-type');
+    const saleAmountInput = document.getElementById('sale-amount');
+    const saleStatusInput = document.getElementById('sale-status');
+    const saleFeedback = document.getElementById('sale-feedback');
+
+    function setDefaultDateTime() {
+      const now = new Date();
+      const local = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
+      saleDateInput.value = local.toISOString().slice(0, 16);
+    }
+
+    addSaleForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+
+      const dateValue = saleDateInput.value;
+      const amountValue = Number(saleAmountInput.value);
+
+      if (!dateValue || Number.isNaN(amountValue) || amountValue <= 0) {
+        saleFeedback.textContent = 'Enter a valid date and positive amount to record the sale.';
+        saleFeedback.classList.remove('text-emerald-600', 'dark:text-emerald-300');
+        saleFeedback.classList.add('text-amber-600', 'dark:text-amber-300');
+        return;
+      }
+
+      const saleDate = new Date(dateValue);
+      const formattedDate = dateTimeFormatter.format(saleDate);
+      const typeValue = saleTypeInput.value.trim() || 'Other';
+      const statusValue = saleStatusInput.value;
+
+      payouts.unshift({
+        date: formattedDate,
+        type: typeValue,
+        amount: amountValue,
+        status: statusValue,
+        timestamp: saleDate.getTime(),
+      });
+
+      saleAmountInput.value = '';
+      saleTypeInput.value = '';
+      saleStatusInput.value = 'Paid';
+      setDefaultDateTime();
+
+      saleFeedback.textContent = 'Sale added! Projections and profitability have been updated.';
+      saleFeedback.classList.remove('text-amber-600', 'dark:text-amber-300');
+      saleFeedback.classList.add('text-emerald-600', 'dark:text-emerald-300');
+
+      renderDashboard();
+    });
+
+    setDefaultDateTime();
+    renderDashboard();
+
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an ROI estimator that accounts for recurring $147 annual DashNex fees when projecting future profitability
- allow logging new affiliate payouts so tables, summaries, and projections stay current without code changes
- refresh metrics rendering to recalculate ROI, totals, and payback status whenever data or projections change

## Testing
- Not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68dca3df68a88320b00a539b82f8ff28